### PR TITLE
Retrieve -postoffset value from correct style in combobox

### DIFF
--- a/library/ttk/combobox.tcl
+++ b/library/ttk/combobox.tcl
@@ -368,7 +368,8 @@ proc ttk::combobox::PlacePopdown {cb popdown} {
     set y [winfo rooty $cb]
     set w [winfo width $cb]
     set h [winfo height $cb]
-    set postoffset [ttk::style lookup TCombobox -postoffset {} {0 0 0 0}]
+    set style [$cb cget -style]
+    set postoffset [ttk::style lookup $style -postoffset {} {0 0 0 0}]
     foreach var {x y w h} delta $postoffset {
     	incr $var $delta
     }


### PR DESCRIPTION
The actual combobox.tcl implementation reads the "-postoffset" value from the "TCombobox" style, instead of reading it from the style actually applied to the widget. It is therefore impossible to customize this property in a derived style. This commit fixes it.